### PR TITLE
지하철역 인수테스트 작성

### DIFF
--- a/src/test/java/subway/RestAssuredTest.java
+++ b/src/test/java/subway/RestAssuredTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
+import static io.restassured.RestAssured.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -16,7 +17,10 @@ public class RestAssuredTest {
     @Test
     void accessGoogle() {
         // TODO: 구글 페이지 요청 구현
-        ExtractableResponse<Response> response = null;
+        ExtractableResponse<Response> response =
+                given().log().all()
+                                .when().get("https://www.google.co.kr/")
+                                .then().log().status().extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -28,15 +28,18 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStationTest() {
+        // Given
+        String stationName = "강남역";
+
         // When
-        ExtractableResponse<Response> response = createStation("강남역");
+        ExtractableResponse<Response> response = createStation(stationName);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // Then
         List<String> stationNames = getStations();
-        assertThat(stationNames).contains("강남역");
+        assertThat(stationNames).contains(stationName);
     }
 
     /**
@@ -67,7 +70,8 @@ public class StationAcceptanceTest {
     @Test
     void deleteStationTest() {
         // Given
-        int stationId = createStation("강남역")
+        String stationName = "강남역";
+        int stationId = createStation(stationName)
                 .body()
                 .jsonPath()
                 .get("id");
@@ -78,7 +82,7 @@ public class StationAcceptanceTest {
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         List<String> stationNames = getStations();
-        assertThat(stationNames).doesNotContain("강남역");
+        assertThat(stationNames).doesNotContain(stationName);
     }
 
     ExtractableResponse<Response> createStation(String stationName) {

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -19,13 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
     private static final String basePath = "/stations";
+    private static final String GANGNAM_STATION = "강남역";
+    private static final String SEOUL_STATION = "서울역";
 
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStationTest() {
-        // Given
-        String GANGNAM_STATION = "강남역";
-
         // When
         지하철역_생성(GANGNAM_STATION);
 
@@ -38,8 +37,6 @@ public class StationAcceptanceTest {
     @Test
     void getStationsTest() {
         // Given
-        String GANGNAM_STATION = "강남역";
-        String SEOUL_STATION = "서울역";
         지하철역_생성(GANGNAM_STATION);
         지하철역_생성(SEOUL_STATION);
 
@@ -54,7 +51,6 @@ public class StationAcceptanceTest {
     @Test
     void deleteStationTest() {
         // Given
-        String GANGNAM_STATION = "강남역";
         int stationId = 지하철역_생성(GANGNAM_STATION)
                 .body()
                 .jsonPath()

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -71,10 +71,7 @@ public class StationAcceptanceTest {
                 .get("id");
 
         // When
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when().delete("/stations/" + stationId)
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = deleteStation(stationId);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -101,5 +98,10 @@ public class StationAcceptanceTest {
                 .extract().jsonPath().getList("name", String.class);
     }
 
-
+    ExtractableResponse<Response> deleteStation(int stationId) {
+        return RestAssured.given().log().all()
+                .when().delete("/stations/" + stationId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -59,10 +59,9 @@ public class StationAcceptanceTest {
                 .get("id");
 
         // When
-        ExtractableResponse<Response> response = 지하철역_삭제(stationId);
+        지하철역_삭제(stationId);
 
         // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         List<String> stationNames = 지하철역_조회();
         assertThat(stationNames).doesNotContain(GANGNAM_STATION);
     }
@@ -95,6 +94,7 @@ public class StationAcceptanceTest {
                 .pathParam("stationId", stationId)
                 .when().delete("/{stationId}")
                 .then().log().all()
+                .assertThat().statusCode(HttpStatus.NO_CONTENT.value())
                 .extract();
     }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -27,10 +27,7 @@ public class StationAcceptanceTest {
         String GANGNAM_STATION = "강남역";
 
         // When
-        ExtractableResponse<Response> response = 지하철역_생성(GANGNAM_STATION);
-
-        // Then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        지하철역_생성(GANGNAM_STATION);
 
         // Then
         List<String> stationNames = 지하철역_조회();
@@ -80,6 +77,7 @@ public class StationAcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post()
                 .then().log().all()
+                .assertThat().statusCode(HttpStatus.CREATED.value())
                 .extract();
     }
 

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -24,17 +24,17 @@ public class StationAcceptanceTest {
     @Test
     void createStationTest() {
         // Given
-        String stationName = "강남역";
+        String GANGNAM_STATION = "강남역";
 
         // When
-        ExtractableResponse<Response> response = 지하철역_생성(stationName);
+        ExtractableResponse<Response> response = 지하철역_생성(GANGNAM_STATION);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // Then
         List<String> stationNames = 지하철역_조회();
-        assertThat(stationNames).contains(stationName);
+        assertThat(stationNames).contains(GANGNAM_STATION);
     }
 
     @DisplayName("지하철역 목록을 조회한다.")
@@ -55,8 +55,8 @@ public class StationAcceptanceTest {
     @Test
     void deleteStationTest() {
         // Given
-        String stationName = "강남역";
-        int stationId = 지하철역_생성(stationName)
+        String GANGNAM_STATION = "강남역";
+        int stationId = 지하철역_생성(GANGNAM_STATION)
                 .body()
                 .jsonPath()
                 .get("id");
@@ -67,7 +67,7 @@ public class StationAcceptanceTest {
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
         List<String> stationNames = 지하철역_조회();
-        assertThat(stationNames).doesNotContain(stationName);
+        assertThat(stationNames).doesNotContain(GANGNAM_STATION);
     }
 
     private ExtractableResponse<Response> 지하철역_생성(String stationName) {

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -46,8 +46,8 @@ public class StationAcceptanceTest {
     @Test
     void getStationsTest() {
         // Given
-        ExtractableResponse<Response> response1 = createStation("강남역");
-        ExtractableResponse<Response> response2 = createStation("서울역");
+        createStation("강남역");
+        createStation("서울역");
 
         // When
         List<String> stationNames = getStations();

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -34,7 +34,7 @@ public class StationAcceptanceTest {
 
         // Then
         List<String> stationNames = getStations();
-        assertThat(stationNames).containsExactly("강남역");
+        assertThat(stationNames).contains("강남역");
     }
 
     /**

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
+    private static final String basePath = "/stations";
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
@@ -84,23 +86,27 @@ public class StationAcceptanceTest {
         params.put("name", stationName);
 
         return RestAssured.given().log().all()
+                .basePath(basePath)
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations")
+                .when().post()
                 .then().log().all()
                 .extract();
     }
 
     List<String> getStations() {
         return RestAssured.given().log().all()
-                .when().get("/stations")
+                .basePath(basePath)
+                .when().get()
                 .then().log().all()
                 .extract().jsonPath().getList("name", String.class);
     }
 
     ExtractableResponse<Response> deleteStation(int stationId) {
         return RestAssured.given().log().all()
-                .when().delete("/stations/" + stationId)
+                .basePath(basePath)
+                .pathParam("stationId", stationId)
+                .when().delete("/{stationId}")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -20,11 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StationAcceptanceTest {
     private static final String basePath = "/stations";
 
-    /**
-     * When 지하철역을 생성하면
-     * Then 지하철역이 생성된다
-     * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
-     */
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStationTest() {
@@ -32,60 +27,50 @@ public class StationAcceptanceTest {
         String stationName = "강남역";
 
         // When
-        ExtractableResponse<Response> response = createStation(stationName);
+        ExtractableResponse<Response> response = 지하철역_생성(stationName);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // Then
-        List<String> stationNames = getStations();
+        List<String> stationNames = 지하철역_조회();
         assertThat(stationNames).contains(stationName);
     }
 
-    /**
-     * Given 2개의 지하철역을 생성하고
-     * When 지하철역 목록을 조회하면
-     * Then 2개의 지하철역을 응답 받는다
-     */
     @DisplayName("지하철역 목록을 조회한다.")
     @Test
     void getStationsTest() {
         // Given
-        createStation("강남역");
-        createStation("서울역");
+        지하철역_생성("강남역");
+        지하철역_생성("서울역");
 
         // When
-        List<String> stationNames = getStations();
+        List<String> stationNames = 지하철역_조회();
 
         // Then
         assertThat(stationNames.size()).isEqualTo(2);
     }
 
-    /**
-     * Given 지하철역을 생성하고
-     * When 그 지하철역을 삭제하면
-     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
-     */
     @DisplayName("지하철역을 삭제한다.")
     @Test
     void deleteStationTest() {
         // Given
         String stationName = "강남역";
-        int stationId = createStation(stationName)
+        int stationId = 지하철역_생성(stationName)
                 .body()
                 .jsonPath()
                 .get("id");
 
         // When
-        ExtractableResponse<Response> response = deleteStation(stationId);
+        ExtractableResponse<Response> response = 지하철역_삭제(stationId);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-        List<String> stationNames = getStations();
+        List<String> stationNames = 지하철역_조회();
         assertThat(stationNames).doesNotContain(stationName);
     }
 
-    ExtractableResponse<Response> createStation(String stationName) {
+    private ExtractableResponse<Response> 지하철역_생성(String stationName) {
         Map<String, String> params = new HashMap<>();
         params.put("name", stationName);
 
@@ -98,7 +83,7 @@ public class StationAcceptanceTest {
                 .extract();
     }
 
-    List<String> getStations() {
+    private List<String> 지하철역_조회() {
         return RestAssured.given().log().all()
                 .basePath(basePath)
                 .when().get()
@@ -106,7 +91,7 @@ public class StationAcceptanceTest {
                 .extract().jsonPath().getList("name", String.class);
     }
 
-    ExtractableResponse<Response> deleteStation(int stationId) {
+    private ExtractableResponse<Response> 지하철역_삭제(int stationId) {
         return RestAssured.given().log().all()
                 .basePath(basePath)
                 .pathParam("stationId", stationId)

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -38,8 +38,10 @@ public class StationAcceptanceTest {
     @Test
     void getStationsTest() {
         // Given
-        지하철역_생성("강남역");
-        지하철역_생성("서울역");
+        String GANGNAM_STATION = "강남역";
+        String SEOUL_STATION = "서울역";
+        지하철역_생성(GANGNAM_STATION);
+        지하철역_생성(SEOUL_STATION);
 
         // When
         List<String> stationNames = 지하철역_조회();

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -34,7 +34,7 @@ public class StationAcceptanceTest {
 
         // Then
         List<String> stationNames = getStations();
-        assertThat(stationNames).containsAnyOf("강남역");
+        assertThat(stationNames).containsExactly("강남역");
     }
 
     /**

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -25,28 +25,15 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
-    void createStation() {
-        // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+    void createStationTest() {
+        // When
+        ExtractableResponse<Response> response = createStation("강남역");
 
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
-
-        // then
+        // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-        // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
+        // Then
+        List<String> stationNames = getStations();
         assertThat(stationNames).containsAnyOf("강남역");
     }
 
@@ -55,13 +42,64 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void getStationsTest() {
+        // Given
+        ExtractableResponse<Response> response1 = createStation("강남역");
+        ExtractableResponse<Response> response2 = createStation("서울역");
+
+        // When
+        List<String> stationNames = getStations();
+
+        // Then
+        assertThat(stationNames.size()).isEqualTo(2);
+    }
 
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 삭제한다.")
+    @Test
+    void deleteStationTest() {
+        // Given
+        int stationId = createStation("강남역")
+                .body()
+                .jsonPath()
+                .get("id");
+
+        // When
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .when().delete("/stations/" + stationId)
+                .then().log().all()
+                .extract();
+
+        // Then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        List<String> stationNames = getStations();
+        assertThat(stationNames).doesNotContain("강남역");
+    }
+
+    ExtractableResponse<Response> createStation(String stationName) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", stationName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    List<String> getStations() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+    }
+
 
 }


### PR DESCRIPTION
### 지하철역 생성, 조회, 삭제 기능 인수테스트
- 지하철역 생성, 조회, 삭제 메소드 분리
---
**이슈**
- 지하철역 생성 메소드를 여러 곳에서 호출하는데, 반환값(ExtractableResponse)이 필요한 곳이 있고 필요하지 않은 곳도 있습니다. 현재는 반환값이 있는 메소드(createStation())를 변수에 반환값을 받지 않고 호출만 해두었습니다. 다른 방법이 있을까요?